### PR TITLE
Modernize ROS installation script

### DIFF
--- a/setup_ros.sh
+++ b/setup_ros.sh
@@ -6,19 +6,17 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 1
 fi
 
-# Check if the system is Ubuntu 20.04
-if [ "$(lsb_release -rs)" != "20.04" ]; then
-    echo "This script is intended for Ubuntu 20.04 only."
+# Check if the system is Ubuntu 22.04
+if [ "$(lsb_release -rs)" != "22.04" ]; then
+    echo "This script is intended for Ubuntu 22.04 only."
     exit 1
 fi
 
 apt-get update
-apt-get dist-upgrade
-apt-get install ros-foxy-desktop python3-argcomplete ros-dev-tools
-apt-get install software-properties-common
+apt-get -y full-upgrade
+apt-get install -y software-properties-common curl
 add-apt-repository universe
-apt-get install curl -y
 curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
-apt-get install ros-foxy-desktop python3-argcomplete ros-dev-tools
-apt-get install ros-foxy-orocos-kdl
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+apt-get update
+apt-get install -y ros-humble-desktop python3-argcomplete ros-dev-tools ros-humble-orocos-kdl

--- a/setup_ros.sh
+++ b/setup_ros.sh
@@ -15,7 +15,7 @@ fi
 apt-get update
 apt-get -y full-upgrade
 apt-get install -y software-properties-common curl
-add-apt-repository universe
+add-apt-repository -y universe
 curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
 apt-get update


### PR DESCRIPTION
## Summary
- update `setup_ros.sh` for Ubuntu 22.04 and ROS 2 Humble

## Testing
- `bash -n setup_ros.sh`
- `pwsh -NoProfile -Command "Write-Output 'test run'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c38619bd88333880a9fb96318d4d8